### PR TITLE
Expose flashVer from RTMP connect command

### DIFF
--- a/server_conn.go
+++ b/server_conn.go
@@ -115,6 +115,7 @@ type ServerConn struct {
 	app                  string
 	tcURL                string
 	FourCcList           amf0.StrictArray
+	FlashVer             string
 
 	// filled by Accept
 	URL     *url.URL
@@ -185,6 +186,8 @@ func (c *ServerConn) Initialize() error {
 			c.FourCcList = arr
 		}
 	}
+
+	c.FlashVer, _ = connectObject.GetString("flashVer")
 
 	return nil
 }

--- a/server_conn_test.go
+++ b/server_conn_test.go
@@ -66,6 +66,7 @@ func TestServerConn(t *testing.T) {
 					RawQuery: "key=val",
 				}, conn.URL)
 				require.Equal(t, (ca == "publish"), conn.Publish)
+				require.Equal(t, "LNX 9,0,124,2", conn.FlashVer)
 			}()
 
 			conn, err := net.Dial("tcp", "127.0.0.1:9121")


### PR DESCRIPTION
Extracts the `flashVer` field from the AMF0 connect object during `Initialize()` and stores it as an exported field on `ServerConn`.

This allows consumers to identify the client software connecting via RTMP, similar to a user agent.