### PR TITLE
fix: wall-clock timeout in readTracks, cap ack window, handle SetPeer…

### DIFF
--- a/pkg/message/readwriter.go
+++ b/pkg/message/readwriter.go
@@ -50,6 +50,14 @@ func (rw *ReadWriter) Read() (Message, error) {
 		if err != nil {
 			return nil, err
 		}
+
+	case *SetPeerBandwidth:
+		err = rw.w.Write(&SetWindowAckSize{
+			Value: tmsg.Value,
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return msg, nil

--- a/pkg/rawmessage/reader.go
+++ b/pkg/rawmessage/reader.go
@@ -11,6 +11,15 @@ import (
 	"github.com/bluenviron/gortmplib/pkg/chunk"
 )
 
+const (
+	// maxAckWindowSize is the upper bound for the RTMP acknowledgement window.
+	// Servers may request very large windows (e.g. 5MB), but on low-bitrate
+	// streams this prevents any Ack from being sent within the read timeout,
+	// causing the server to stop sending data. 64KB ensures at least one Ack
+	// per 60s for streams >= 10kbps.
+	maxAckWindowSize = 64000
+)
+
 var errMoreChunksNeeded = errors.New("more chunks are needed")
 
 const (
@@ -257,11 +266,12 @@ func NewReader(
 	onAckNeeded func(uint32) error,
 ) *Reader {
 	return &Reader{
-		bcr:          bcr,
-		br:           bufio.NewReader(r),
-		onAckNeeded:  onAckNeeded,
-		chunkSize:    128,
-		chunkStreams: make(map[byte]*readerChunkStream),
+		bcr:           bcr,
+		br:            bufio.NewReader(r),
+		onAckNeeded:   onAckNeeded,
+		ackWindowSize: 2500000,
+		chunkSize:     128,
+		chunkStreams:  make(map[byte]*readerChunkStream),
 	}
 }
 
@@ -277,6 +287,9 @@ func (r *Reader) SetChunkSize(v uint32) error {
 
 // SetWindowAckSize sets the window acknowledgement size.
 func (r *Reader) SetWindowAckSize(v uint32) {
+	if v > maxAckWindowSize {
+		v = maxAckWindowSize
+	}
 	r.ackWindowSize = v
 }
 

--- a/reader.go
+++ b/reader.go
@@ -294,6 +294,8 @@ func (r *Reader) readTracks() (map[uint8]*Track, map[uint8]*Track, error) {
 	videoTracks := make(map[uint8]*Track)
 	audioTracks := make(map[uint8]*Track)
 
+	loopStart := time.Now()
+
 	handleVideoSequenceStart := func(trackID uint8, msg *message.VideoExSequenceStart) error {
 		if videoTracks[trackID] != nil {
 			return fmt.Errorf("video track %d already setupped", trackID)
@@ -486,7 +488,7 @@ func (r *Reader) readTracks() (map[uint8]*Track, map[uint8]*Track, error) {
 			}
 		}
 
-		if (curTime - startTime) >= analyzePeriod {
+		if (curTime - startTime) >= analyzePeriod || time.Since(loopStart) >= analyzePeriod {
 			break
 		}
 	}


### PR DESCRIPTION
…Bandwidth

- readTracks: add wall-clock fallback (2s) to prevent infinite loop on pure-audio streams with DTS=0
- rawmessage.Reader: cap ackWindowSize to 64KB and set default to 2.5MB to ensure acks are sent within read timeout on low-bitrate streams
- message.ReadWriter: respond to SetPeerBandwidth with SetWindowAckSize