### PR TITLE
reader: support empty H264 configs (bluenviron/mediamtx#6132)

### DIFF
--- a/pkg/message/msg_video.go
+++ b/pkg/message/msg_video.go
@@ -77,11 +77,13 @@ func (m *Video) unmarshal(raw *rawmessage.Message) error {
 	case VideoTypeConfig:
 		switch m.Codec {
 		case CodecH264:
-			m.AVCConfig = &mp4.AVCDecoderConfiguration{}
-			m.AVCConfig.SetType(mp4.BoxTypeAvcC())
-			_, err := mp4.Unmarshal(bytes.NewReader(raw.Body[5:]), uint64(len(raw.Body[5:])), m.AVCConfig, mp4.Context{})
-			if err != nil {
-				return fmt.Errorf("unable to parse H264 config: %w", err)
+			if len(raw.Body) > 5 {
+				m.AVCConfig = &mp4.AVCDecoderConfiguration{}
+				m.AVCConfig.SetType(mp4.BoxTypeAvcC())
+				_, err := mp4.Unmarshal(bytes.NewReader(raw.Body[5:]), uint64(len(raw.Body[5:])), m.AVCConfig, mp4.Context{})
+				if err != nil {
+					return fmt.Errorf("unable to parse H264 config: %w", err)
+				}
 			}
 
 		case CodecH265:
@@ -109,12 +111,14 @@ func (m Video) marshal() (*rawmessage.Message, error) {
 	case VideoTypeConfig:
 		switch m.Codec {
 		case CodecH264:
-			var buf bytes.Buffer
-			_, err := mp4.Marshal(&buf, m.AVCConfig, mp4.Context{})
-			if err != nil {
-				return nil, err
+			if m.AVCConfig != nil {
+				var buf bytes.Buffer
+				_, err := mp4.Marshal(&buf, m.AVCConfig, mp4.Context{})
+				if err != nil {
+					return nil, err
+				}
+				bodyData = buf.Bytes()
 			}
-			bodyData = buf.Bytes()
 
 		case CodecH265:
 			var buf bytes.Buffer

--- a/pkg/message/reader_test.go
+++ b/pkg/message/reader_test.go
@@ -500,6 +500,23 @@ var readWriterCases = []struct {
 		},
 	},
 	{
+		"video h264 nil config",
+		&message.Video{
+			ChunkStreamID:   6,
+			DTS:             2543534 * time.Millisecond,
+			MessageStreamID: 0x1000000,
+			Codec:           message.CodecH264,
+			IsKeyFrame:      true,
+			Type:            message.VideoTypeConfig,
+			AVCConfig:       nil,
+		},
+		[]byte{
+			0x06, 0x26, 0xcf, 0xae, 0x00, 0x00, 0x05, 0x09,
+			0x01, 0x00, 0x00, 0x00, 0x17, 0x00, 0x00, 0x00,
+			0x00,
+		},
+	},
+	{
 		"video h265 config",
 		&message.Video{
 			ChunkStreamID:   6,

--- a/reader.go
+++ b/reader.go
@@ -381,9 +381,11 @@ func (r *Reader) readTracks() (map[uint8]*Track, map[uint8]*Track, error) {
 			if msg.Type == message.VideoTypeConfig && videoTracks[0] == nil {
 				switch msg.Codec {
 				case message.CodecH264:
-					videoTracks[0], err = h264TrackFromConfig(msg.AVCConfig)
-					if err != nil {
-						return nil, nil, err
+					if msg.AVCConfig != nil {
+						videoTracks[0], err = h264TrackFromConfig(msg.AVCConfig)
+						if err != nil {
+							return nil, nil, err
+						}
 					}
 
 				case message.CodecH265:
@@ -661,6 +663,10 @@ func (r *Reader) OnDataH264(track *Track, cb OnDataH26xFunc) {
 		case *message.Video:
 			switch msg.Type {
 			case message.VideoTypeConfig:
+				if msg.AVCConfig == nil {
+					return nil
+				}
+
 				if msg.AVCConfig.NumOfSequenceParameterSets < 1 {
 					return fmt.Errorf("no SPS found")
 				}

--- a/reader_test.go
+++ b/reader_test.go
@@ -583,6 +583,40 @@ func TestReadTracks(t *testing.T) {
 			},
 		},
 		{
+			"issue mediamtx/6132 (empty H264 config)",
+			[]*gortmplib.Track{{Codec: &codecs.H264{
+				SPS: testCodecH264.SPS,
+				PPS: testCodecH264.PPS,
+			}}},
+			[]message.Message{
+				&message.Video{
+					ChunkStreamID:   message.VideoChunkStreamID,
+					MessageStreamID: 0x1000000,
+					Codec:           message.CodecH264,
+					IsKeyFrame:      true,
+					Type:            message.VideoTypeConfig,
+					AVCConfig:       nil,
+				},
+				&message.Video{
+					ChunkStreamID:   message.VideoChunkStreamID,
+					MessageStreamID: 0x1000000,
+					Codec:           message.CodecH264,
+					IsKeyFrame:      true,
+					Type:            message.VideoTypeConfig,
+					AVCConfig:       generateAvcC(testCodecH264.SPS, testCodecH264.PPS),
+				},
+				&message.Video{
+					ChunkStreamID:   message.VideoChunkStreamID,
+					DTS:             2 * time.Second,
+					MessageStreamID: 0x1000000,
+					Codec:           message.CodecH264,
+					IsKeyFrame:      true,
+					Type:            message.VideoTypeAU,
+					AU:              []byte{1},
+				},
+			},
+		},
+		{
 			"issue mediamtx/2232 (xsplit broadcaster)",
 			[]*gortmplib.Track{
 				{Codec: &codecs.H265{
@@ -1959,4 +1993,68 @@ func TestReaderRewind(t *testing.T) {
 	}
 
 	require.Equal(t, 3, receivedCount)
+}
+
+func TestReaderEmptyH264Config(t *testing.T) {
+	messages := []message.Message{
+		&message.Video{
+			ChunkStreamID:   message.VideoChunkStreamID,
+			MessageStreamID: 0x1000000,
+			Codec:           message.CodecH264,
+			IsKeyFrame:      true,
+			Type:            message.VideoTypeConfig,
+			AVCConfig:       nil,
+		},
+		&message.Video{
+			ChunkStreamID:   message.VideoChunkStreamID,
+			MessageStreamID: 0x1000000,
+			Codec:           message.CodecH264,
+			IsKeyFrame:      true,
+			Type:            message.VideoTypeConfig,
+			AVCConfig:       generateAvcC(testCodecH264.SPS, testCodecH264.PPS),
+		},
+		&message.Video{
+			ChunkStreamID:   message.VideoChunkStreamID,
+			DTS:             2 * time.Second,
+			MessageStreamID: 0x1000000,
+			Codec:           message.CodecH264,
+			IsKeyFrame:      true,
+			Type:            message.VideoTypeAU,
+			AU:              []byte{0x00, 0x00, 0x00, 0x02, 0x09, 0xf0},
+		},
+	}
+
+	var buf bytes.Buffer
+	bc := bytecounter.NewReadWriter(&buf)
+	mrw := message.NewReadWriter(bc, bc, true)
+
+	for _, msg := range messages {
+		err := mrw.Write(msg)
+		require.NoError(t, err)
+	}
+
+	c := &dummyConn{rw: &buf}
+	c.initialize()
+
+	r := &gortmplib.Reader{Conn: c}
+	err := r.Initialize()
+	require.NoError(t, err)
+
+	tracks := r.Tracks()
+	require.Equal(t, []*gortmplib.Track{{Codec: &codecs.H264{
+		SPS: testCodecH264.SPS,
+		PPS: testCodecH264.PPS,
+	}}}, tracks)
+
+	receivedCount := 0
+	r.OnDataH264(tracks[0], func(_ time.Duration, _ time.Duration, _ [][]byte) {
+		receivedCount++
+	})
+
+	for range 3 {
+		err = r.Read()
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, 2, receivedCount)
 }


### PR DESCRIPTION
Fixes bluenviron/mediamtx#6132